### PR TITLE
Fixed HMAC hash computation error

### DIFF
--- a/shopify.php
+++ b/shopify.php
@@ -19,7 +19,19 @@
 			unset($query_params['signature']);
 			unset($query_params['hmac']);
 			ksort($query_params);
-			return $hmac == hash_hmac('sha256', http_build_query($query_params), $shared_secret);
+
+			foreach($query_params as $param => $value) {
+				$param = str_replace('%', '%25', $param);
+				$param = str_replace('&', '%26', $param);
+				$param = str_replace('=', '%3D', $param);
+
+				$value = str_replace('%', '%25', $value);
+				$value = str_replace('&', '%26', $value);
+
+				$params[$param] = "{$param}={$value}";
+			}
+
+			return $hmac == hash_hmac('sha256', implode('&', $params), $shared_secret);
 		}
 		return false;
 	}


### PR DESCRIPTION
Changed invocation of `http_build_query` onto encoding only a few characters in GET param keys / values. According to Shopify documentation only %, & need to be encoded in both key a values of GET params. Moreover = character need to be encoded in GET key value.

`http_build_query` is encoding much more characters and is causing HMAC to be computed from not correctly build string.